### PR TITLE
[Fix] Compatibility Issues with Custom Payload Changes in 1.20.5+

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,14 +19,7 @@ dependencies {
 	minecraft "com.mojang:minecraft:${project.minecraft_version}"
 	mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
 	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
-
-	// Fabric API. This is technically optional, but you probably want it anyway.
-	// modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
-
-	// Uncomment the following line to enable the deprecated Fabric API modules. 
-	// These are included in the Fabric API production distribution and allow you to update your mod to the latest modules at a later more convenient time.
-
-	// modImplementation "net.fabricmc.fabric-api:fabric-api-deprecated:${project.fabric_version}"
+	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 }
 
 base {

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,3 +10,4 @@ archives_base_name=autototem
 minecraft_version=1.21.4
 yarn_mappings=1.21.4+build.1
 loader_version=0.16.9
+fabric_version=0.102.0+1.21

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,4 +10,4 @@ archives_base_name=autototem
 minecraft_version=1.21.4
 yarn_mappings=1.21.4+build.1
 loader_version=0.16.9
-fabric_version=0.102.0+1.21
+fabric_version=0.110.5+1.21.4

--- a/src/main/java/mike/autototem/client/AutototemClient.java
+++ b/src/main/java/mike/autototem/client/AutototemClient.java
@@ -1,11 +1,15 @@
 package mike.autototem.client;
 
+import mike.autototem.packets.OptOutPacket;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
+import net.fabricmc.fabric.api.networking.v1.PayloadTypeRegistry;
 
 @Environment(EnvType.CLIENT)
 public class AutototemClient implements ClientModInitializer {
     @Override
-    public void onInitializeClient() { }
+    public void onInitializeClient() {
+        PayloadTypeRegistry.playC2S().register(OptOutPacket.ID, OptOutPacket.CODEC);
+    }
 }

--- a/src/main/java/mike/autototem/mixin/ServerOptOut.java
+++ b/src/main/java/mike/autototem/mixin/ServerOptOut.java
@@ -1,10 +1,9 @@
 package mike.autototem.mixin;
 
+import mike.autototem.packets.OptOutPacket;
+import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
 import net.minecraft.client.network.ClientPlayNetworkHandler;
-import net.minecraft.network.packet.UnknownCustomPayload;
-import net.minecraft.network.packet.c2s.common.CustomPayloadC2SPacket;
 import net.minecraft.network.packet.s2c.play.GameJoinS2CPacket;
-import net.minecraft.util.Identifier;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -14,12 +13,6 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 public class ServerOptOut {
     @Inject(at = @At("TAIL"), method = "onGameJoin")
     private void sendInfoPackage(GameJoinS2CPacket packet, CallbackInfo ci) {
-        ClientPlayNetworkHandler networkHandler = (ClientPlayNetworkHandler) ((Object) this);
-
-        networkHandler.sendPacket(
-            new CustomPayloadC2SPacket(
-                new UnknownCustomPayload(Identifier.of("autototem-fabric"))
-            )
-        );
+        ClientPlayNetworking.send(new OptOutPacket());
     }
 }

--- a/src/main/java/mike/autototem/packets/OptOutPacket.java
+++ b/src/main/java/mike/autototem/packets/OptOutPacket.java
@@ -1,0 +1,29 @@
+package mike.autototem.packets;
+
+import io.netty.buffer.Unpooled;
+import net.minecraft.network.RegistryByteBuf;
+import net.minecraft.network.codec.PacketCodec;
+import net.minecraft.network.packet.CustomPayload;
+import net.minecraft.util.Identifier;
+import org.jetbrains.annotations.NotNull;
+
+public class OptOutPacket implements CustomPayload {
+    public static final CustomPayload.Id<OptOutPacket> ID = new CustomPayload.Id<>(Identifier.tryParse("autototem-fabric"));
+
+    public static final PacketCodec<RegistryByteBuf, OptOutPacket> CODEC = new PacketCodec<>() {
+        @Override
+        public void encode(RegistryByteBuf buffer, OptOutPacket optOutPacket) {
+            Unpooled.buffer();
+        }
+
+        @Override
+        public @NotNull OptOutPacket decode(RegistryByteBuf buffer) {
+            return new OptOutPacket();
+        }
+    };
+
+    @Override
+    public Id<? extends CustomPayload> getId() {
+        return ID;
+    }
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -21,6 +21,7 @@
   ],
   "depends": {
     "fabricloader": "*",
+    "fabric-api": "*",
     "minecraft": "*"
   }
 }


### PR DESCRIPTION
### Fix Compatibility Issues with Custom Payload Changes in 1.20.5+  

Since Minecraft 1.20.5+, major changes have been introduced to the custom payload networking logic. The current implementation conflicts with these changes, causing clients like Lunar Client to fail with the following error when attempting to join a server using this mod:  

![Error Screenshot](https://github.com/user-attachments/assets/c5319085-9d06-4adf-897a-cc94c1611a78)  

To resolve this, I implemented a proper opt-out packet registered through the Fabric API, following the [Fabric documentation](https://wiki.fabricmc.net/tutorial:networking#networking_in_1205).

This update ensures compatibility with launchers like Lunar Client and likely many others, as the previous implementation did not align with Minecraft's default networking logic and was prone to breaking.  
